### PR TITLE
:bug: Fix Nest.js cannot resolve dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,15 @@
     "node": "16.18.0",
     "yarn": "1.22.19"
   },
-  "workspaces": [
-    "apps/*"
-  ],
+  "workspaces": {
+    "packages": [
+      "apps/*"
+    ],
+    "nohoist": [
+      "**/@nestjs/**",
+      "**/@fastify/**"
+    ]
+  },
   "dependencies": {
     "lerna": "^6.0.1"
   }


### PR DESCRIPTION
## Problem
- Nest.js does not work in some situations with "hoist" feature of yarn workspace
- Ref: https://docs.nestjs.com/faq/common-errors#cannot-resolve-dependency-error

## Solution
- Add "nohoist" setting to the root `package.json`