### PR TITLE
:sparkles: Add Scraping Jobs to Queue when the keywords file is uploaded

### DIFF
--- a/apps/api/src/report/report.module.ts
+++ b/apps/api/src/report/report.module.ts
@@ -1,3 +1,4 @@
+import { BullModule } from '@nestjs/bull';
 import { Module } from '@nestjs/common';
 import { ReportService } from './report.service';
 import { ReportController } from './report.controller';
@@ -6,6 +7,11 @@ import { ScrapingJobService } from './scraping-job/scraping-job.service';
 import { ScrapingJobController } from './scraping-job/scraping-job.controller';
 
 @Module({
+  imports: [
+    BullModule.registerQueue({
+      name: 'scraping',
+    }),
+  ],
   controllers: [ReportController, ScrapingJobController],
   providers: [ReportService, PrismaService, ScrapingJobService],
 })

--- a/apps/api/src/report/scraping-job/scraping-job.controller.spec.ts
+++ b/apps/api/src/report/scraping-job/scraping-job.controller.spec.ts
@@ -6,6 +6,10 @@ import { ScrapingJobService } from './scraping-job.service';
 import { PrismaService } from '../../prisma.service';
 import { userBuilder } from '../../../test/utils/mock';
 import { ReportStatus } from '@prisma/client';
+import { BullModule, getQueueToken } from '@nestjs/bull';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import configuration from '../../config/configuration';
+import { Queue } from 'bull';
 
 const mockUser = userBuilder();
 
@@ -22,15 +26,25 @@ function reqBuilder(overrides: Record<string, any> = {}) {
 describe('ScrapingJobController', () => {
   let controller: ScrapingJobController;
   let prisma: PrismaService;
+  let queue: Queue;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          load: [configuration],
+        }),
+        BullModule.registerQueue({
+          name: 'scraping',
+        }),
+      ],
       controllers: [ScrapingJobController],
-      providers: [ScrapingJobService, PrismaService],
+      providers: [ScrapingJobService, PrismaService, ConfigService],
     }).compile();
 
     controller = module.get<ScrapingJobController>(ScrapingJobController);
     prisma = module.get<PrismaService>(PrismaService);
+    queue = module.get<Queue>(getQueueToken('scraping'));
 
     await prisma.user.create({
       data: mockUser,
@@ -93,6 +107,48 @@ describe('ScrapingJobController', () => {
       });
       expect(createdReports.map(({ keyword }) => keyword)).toEqual(keywords);
     });
+    it('add scrape jobs to queue (Max Attempt: 3, Timeout: 1 minute, Remove on complete)', async () => {
+      const testFilename = 'valid.csv';
+      const testFilePath = path.join(__dirname + '/test', testFilename);
+      const mockReq = reqBuilder({
+        file: () => {
+          return {
+            filename: testFilename,
+            file: fs.createReadStream(testFilePath),
+          };
+        },
+      });
+
+      const { scrapingJob } = await controller.uploadKeywords(mockReq);
+
+      const createdReports = await prisma.report.findMany({
+        where: {
+          scrapingJobId: scrapingJob.id,
+        },
+      });
+
+      const jobs = (
+        await Promise.all(
+          createdReports.map((report) => queue.getJob(report.id)),
+        )
+      ).filter((job) => job !== null);
+
+      const ONE_MINUTE_IN_MS = 60 * 1000;
+      createdReports.forEach((report, index) => {
+        const job = jobs[index];
+        expect(job).toMatchObject({
+          opts: {
+            attempts: 3,
+            timeout: ONE_MINUTE_IN_MS,
+            removeOnComplete: true,
+          },
+          data: {
+            reportId: report.id,
+            keyword: report.keyword,
+          },
+        });
+      });
+    });
   });
 
   afterEach(async () => {
@@ -101,6 +157,7 @@ describe('ScrapingJobController', () => {
     const deleteReports = prisma.report.deleteMany();
 
     await prisma.$transaction([deleteScrapingJobs, deleteReports, deleteUsers]);
+    await queue.empty();
   });
 
   afterAll(async () => {

--- a/apps/api/src/report/scraping-job/scraping-job.controller.spec.ts
+++ b/apps/api/src/report/scraping-job/scraping-job.controller.spec.ts
@@ -136,16 +136,15 @@ describe('ScrapingJobController', () => {
       const ONE_MINUTE_IN_MS = 60 * 1000;
       createdReports.forEach((report, index) => {
         const job = jobs[index];
-        expect(job).toMatchObject({
-          opts: {
-            attempts: 3,
-            timeout: ONE_MINUTE_IN_MS,
-            removeOnComplete: true,
-          },
-          data: {
-            reportId: report.id,
-            keyword: report.keyword,
-          },
+        expect(job.opts).toMatchObject({
+          attempts: 3,
+          timeout: ONE_MINUTE_IN_MS,
+          removeOnComplete: true,
+        });
+        expect(job.data).toEqual({
+          reportId: report.id,
+          keyword: report.keyword,
+          scrapingJobId: report.scrapingJobId,
         });
       });
     });

--- a/apps/api/src/report/scraping-job/scraping-job.controller.ts
+++ b/apps/api/src/report/scraping-job/scraping-job.controller.ts
@@ -22,6 +22,8 @@ export class ScrapingJobController {
       userId: req.user.userId,
     });
 
+    await this.scrapingJobService.addJobToQueue(scrapingJob);
+
     return {
       scrapingJob,
     };

--- a/apps/api/src/report/scraping-job/scraping-job.service.ts
+++ b/apps/api/src/report/scraping-job/scraping-job.service.ts
@@ -52,7 +52,11 @@ export class ScrapingJobService {
 
     for (const report of reports) {
       this.reportQueue.add(
-        { reportId: report.id, keyword: report.keyword },
+        {
+          reportId: report.id,
+          keyword: report.keyword,
+          scrapingJobId: report.scrapingJobId,
+        },
         {
           jobId: report.id,
           attempts: 3,

--- a/apps/api/src/report/scraping-job/scraping-job.service.ts
+++ b/apps/api/src/report/scraping-job/scraping-job.service.ts
@@ -1,10 +1,16 @@
-import { Prisma, ReportStatus } from '@prisma/client';
+import { Queue } from 'bull';
+import { InjectQueue } from '@nestjs/bull';
 import { Injectable } from '@nestjs/common';
+import { Prisma, ReportStatus, ScrapingJob } from '@prisma/client';
 import { PrismaService } from '../../prisma.service';
+import { ScrapingJobPayload } from './types';
 
 @Injectable()
 export class ScrapingJobService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    @InjectQueue('scraping') private reportQueue: Queue<ScrapingJobPayload>,
+  ) {}
 
   createFromKeywords({
     filename,
@@ -35,5 +41,25 @@ export class ScrapingJobService {
         },
       },
     });
+  }
+
+  async addJobToQueue(scrapingJob: ScrapingJob) {
+    const reports = await this.prisma.report.findMany({
+      where: {
+        scrapingJobId: scrapingJob.id,
+      },
+    });
+
+    for (const report of reports) {
+      this.reportQueue.add(
+        { reportId: report.id, keyword: report.keyword },
+        {
+          jobId: report.id,
+          attempts: 3,
+          timeout: 1000 * 60,
+          removeOnComplete: true,
+        },
+      );
+    }
   }
 }

--- a/apps/api/src/report/scraping-job/types.ts
+++ b/apps/api/src/report/scraping-job/types.ts
@@ -1,0 +1,4 @@
+export type ScrapingJobPayload = {
+  reportId: string;
+  keyword: string;
+};

--- a/apps/api/src/report/scraping-job/types.ts
+++ b/apps/api/src/report/scraping-job/types.ts
@@ -1,4 +1,5 @@
 export type ScrapingJobPayload = {
   reportId: string;
+  scrapingJobId: string;
   keyword: string;
 };


### PR DESCRIPTION
## Summary

- After the keywords file is uploaded, we add scraping jobs to the queue
- In the next PR, we will add the processor that going to consume this job and scrape the result from Google Search