### PR TITLE
:bug: Fix session is not deleted from cookie when logged out

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -38,6 +38,9 @@ export class AuthController {
   @Post('logout')
   async logout(@Session() session: SecureSession) {
     session.delete();
+    session.options({
+      path: '/',
+    });
 
     return { success: true };
   }


### PR DESCRIPTION
## Summary

:bug: Fix session is not deleted from cookie when logged out
- Because, earlier, we set the cookie path to '/' when users log in
- Therefore, we need to set cookie path to '/' when users log out