### PR TITLE
:sparkles: Add API for getting the specified job

### DIFF
--- a/apps/api/src/report/scraping-job/scraping-job.controller.ts
+++ b/apps/api/src/report/scraping-job/scraping-job.controller.ts
@@ -1,6 +1,14 @@
 import type { BusboyFileStream } from '@fastify/busboy';
 import type { MultipartFile } from '@fastify/multipart';
-import { Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  ForbiddenException,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import * as Papa from 'papaparse';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { ScrapingJobService } from './scraping-job.service';
@@ -40,5 +48,18 @@ export class ScrapingJobController {
         },
       });
     });
+  }
+
+  @Get(':id')
+  async getScrapingJob(@Req() req, @Param('id') id: string) {
+    const scrapingJob = await this.scrapingJobService.findById(id);
+
+    if (req.user.userId !== scrapingJob.userId) {
+      throw new ForbiddenException();
+    }
+
+    return {
+      scrapingJob,
+    };
   }
 }

--- a/apps/api/src/report/scraping-job/scraping-job.service.ts
+++ b/apps/api/src/report/scraping-job/scraping-job.service.ts
@@ -1,6 +1,6 @@
 import { Queue } from 'bull';
 import { InjectQueue } from '@nestjs/bull';
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma, ReportStatus, ScrapingJob } from '@prisma/client';
 import { PrismaService } from '../../prisma.service';
 import { ScrapingJobPayload } from './types';
@@ -64,6 +64,18 @@ export class ScrapingJobService {
           removeOnComplete: true,
         },
       );
+    }
+  }
+
+  async findById(id: string) {
+    try {
+      return await this.prisma.scrapingJob.findUniqueOrThrow({
+        where: {
+          id,
+        },
+      });
+    } catch (error) {
+      throw new NotFoundException(error.message);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add GET `/scrapingJobs/:id` for getting the specified job
  -  Throw 404 Not Found when the specified job does not exist
  -  Throw 403 Forbidden when the current user does not own the specified job