### PR TITLE
:zap: Reduce the time it took to send response back to the client

### DIFF
--- a/apps/api/src/report/report.controller.spec.ts
+++ b/apps/api/src/report/report.controller.spec.ts
@@ -47,9 +47,9 @@ describe('ReportController', () => {
       };
       const { reports } = await controller.getCurrentUserReports(mockRequest);
 
-      const expectedReports = mockReports.filter(
-        (report) => report.userId === mockCurrentUser.id,
-      );
+      const expectedReports = mockReports
+        .filter((report) => report.userId === mockCurrentUser.id)
+        .map(({ html, ...rest }) => rest);
       expect(reports).toEqual(expectedReports);
     });
   });

--- a/apps/api/src/report/report.service.ts
+++ b/apps/api/src/report/report.service.ts
@@ -10,6 +10,19 @@ export class ReportService {
       where: {
         userId,
       },
+      select: {
+        id: true,
+        userId: true,
+        scrapingJobId: true,
+        keyword: true,
+        status: true,
+        totalAdwords: true,
+        totalLinks: true,
+        totalSearchResults: true,
+        html: false,
+        createdAt: true,
+        updatedAt: true,
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary

- For GET `/reports`, the client doesn't need `html` property from Report so we can exclude it, plus this field is extremely large compared to other fields