### PR TITLE
:sparkles: Allow user to search their reports by keyword

### DIFF
--- a/apps/api/prisma/migrations/20221020162318_add_full_text_index_for_reports_keyword/migration.sql
+++ b/apps/api/prisma/migrations/20221020162318_add_full_text_index_for_reports_keyword/migration.sql
@@ -1,0 +1,4 @@
+CREATE EXTENSION pg_trgm;
+CREATE EXTENSION btree_gin;
+CREATE INDEX report_keyword_index 
+   ON reports USING GIN (to_tsvector('english', keyword));

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["fullTextSearch"]
 }
 
 datasource db {

--- a/apps/api/src/report/report.controller.ts
+++ b/apps/api/src/report/report.controller.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   Get,
   Param,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -15,8 +16,14 @@ export class ReportController {
 
   @UseGuards(JwtAuthGuard)
   @Get()
-  async getCurrentUserReports(@Req() req) {
-    const reports = await this.reportService.findAllByUserId(req.user.userId);
+  async getCurrentUserReports(
+    @Req() req,
+    @Query('keyword') keyword: string | undefined,
+  ) {
+    const reports = await this.reportService.findAllByUserIdAndKeyword(
+      req.user.userId,
+      keyword,
+    );
 
     return {
       reports,

--- a/apps/api/src/report/report.service.ts
+++ b/apps/api/src/report/report.service.ts
@@ -6,10 +6,20 @@ import { PrismaService } from '../prisma.service';
 export class ReportService {
   constructor(private prisma: PrismaService) {}
 
-  async findAllByUserId(userId: string) {
+  async findAllByUserIdAndKeyword(userId: string, keyword?: string) {
+    const keywordWhere =
+      keyword ?? ''
+        ? {
+            keyword: {
+              search: keyword,
+            },
+          }
+        : {};
+
     return this.prisma.report.findMany({
       where: {
         userId,
+        ...keywordWhere,
       },
       select: {
         id: true,

--- a/apps/web/pages/reports.tsx
+++ b/apps/web/pages/reports.tsx
@@ -4,7 +4,11 @@ import {
   Flex,
   FormControl,
   Heading,
+  HStack,
+  Icon,
   Input,
+  InputGroup,
+  InputLeftElement,
   Spacer,
   Table,
   TableContainer,
@@ -19,6 +23,8 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { ChangeEventHandler, PropsWithChildren, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { FaSearch } from 'react-icons/fa';
 import { fecthReports, fetchUploadKeywordFile } from '../src/api';
 import { Layout } from '../src/Components/Layout';
 import { useAuth } from '../src/Hooks/useAuth';
@@ -126,11 +132,67 @@ function FileInputButton({
   );
 }
 
+function SearchForm({ keyword }: { keyword: string }) {
+  const { register, handleSubmit, setValue } = useForm<{ keyword: string }>();
+
+  const router = useRouter();
+
+  const onValid: Parameters<typeof handleSubmit>[0] = ({ keyword }) => {
+    if (keyword.length > 1) {
+      router.push(`/reports?keyword=${encodeURIComponent(keyword)}`);
+    } else {
+      router.push(`/reports`);
+    }
+  };
+
+  setValue('keyword', keyword);
+
+  return (
+    <HStack as="form" spacing={4} width="full" onSubmit={handleSubmit(onValid)}>
+      <InputGroup width="full" maxWidth="400px">
+        <InputLeftElement
+          pointerEvents="none"
+          // eslint-disable-next-line react/no-children-prop
+          children={<Icon as={FaSearch} color="blue" />}
+        />
+        <Input
+          {...register('keyword', {
+            setValueAs: (value) => value.trim(),
+          })}
+          type="text"
+          borderRadius="full"
+          backgroundColor="white"
+          enterKeyHint="search"
+        />
+      </InputGroup>
+      <Button
+        type="submit"
+        borderRadius="8px"
+        colorScheme="blue"
+        variant="solid"
+        onClick={() => {}}
+      >
+        Search
+      </Button>
+    </HStack>
+  );
+}
+
 const Reports: NextPage = () => {
   const [{ user }] = useAuth();
   const router = useRouter();
+  const keyword = (router.query.keyword as string) ?? '';
 
-  const { data, isLoading } = useQuery(['my-reports', user?.id], fecthReports);
+  const { data, isLoading } = useQuery(
+    ['my-reports', user?.id, keyword],
+    () => {
+      if (keyword.length === 0) {
+        return fecthReports();
+      } else {
+        return fecthReports(keyword);
+      }
+    }
+  );
   const reports = data?.reports ?? [];
 
   const { mutateAsync: uploadKeywordFile } = useMutation((file: File) => {
@@ -150,6 +212,7 @@ const Reports: NextPage = () => {
     <Layout>
       <Container py={12} minHeight="calc(100vh - 64px)" maxWidth="container.xl">
         <VStack spacing={8} alignItems="start">
+          <SearchForm keyword={keyword} />
           <Flex width="full">
             <Heading>Reports</Heading>
             <Spacer />

--- a/apps/web/pages/reports.tsx
+++ b/apps/web/pages/reports.tsx
@@ -159,7 +159,8 @@ function SearchForm({ keyword }: { keyword: string }) {
           {...register('keyword', {
             setValueAs: (value) => value.trim(),
           })}
-          type="text"
+          type="search"
+          inputMode="search"
           borderRadius="full"
           backgroundColor="white"
           enterKeyHint="search"

--- a/apps/web/pages/reports.tsx
+++ b/apps/web/pages/reports.tsx
@@ -163,6 +163,7 @@ function SearchForm({ keyword }: { keyword: string }) {
           borderRadius="full"
           backgroundColor="white"
           enterKeyHint="search"
+          placeholder="Keyword"
         />
       </InputGroup>
       <Button


### PR DESCRIPTION
## Summary

- 🔧 Enable FullTextSearch for Postgres in Prisma
  - Ref: https://www.prisma.io/docs/concepts/components/prisma-client/full-text-search#enabling-full-text-search
- 🗃️  Add Full Text Index for keyword in Report
- ✨ Allow GET `/reports` to be filtered further by keyword
  - For example, `/reports?keyword=ipad` will find all reports of the current user which contain "ipad" word 
- ✨ Allow users to search their report with keyword

## Preview

<img width="1376" alt="Screen Shot 2565-10-21 at 02 02 48" src="https://user-images.githubusercontent.com/3918933/197035454-d59b97f4-4891-45f2-b223-4858db66d095.png">


