### PR TITLE
:sparkles: Validate CreateUserDto before the execution of POST /auth/local/register

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,8 @@
     "argon2": "^0.30.1",
     "bull": "^4.10.1",
     "cheerio": "^1.0.0-rc.12",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.13.2",
     "papaparse": "^5.3.2",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",

--- a/apps/api/src/auth/dtos/create-user.dto.spec.ts
+++ b/apps/api/src/auth/dtos/create-user.dto.spec.ts
@@ -1,0 +1,79 @@
+import { faker } from '@faker-js/faker';
+import { build } from '@jackfranklin/test-data-bot';
+import { User } from '@prisma/client';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateUserDto } from './create-user.dto';
+
+const dtoBuilder = build<Pick<User, 'name' | 'email' | 'password'>>(
+  'CreateUserDto',
+  {
+    fields: {
+      name: faker.name.fullName(),
+      email: faker.internet.email(),
+      password: faker.internet.password(8),
+    },
+  },
+);
+
+describe('CreateUserDto', () => {
+  it('should pass the validation when it is valid', async () => {
+    const dto = dtoBuilder();
+
+    const obj = plainToInstance(CreateUserDto, dto);
+
+    const errors = await validate(obj);
+    expect(errors).toHaveLength(0);
+  });
+  it('should fail when the given name is empty', async () => {
+    const dto = dtoBuilder({
+      overrides: {
+        name: '',
+      },
+    });
+
+    const obj = plainToInstance(CreateUserDto, dto);
+
+    const errors = await validate(obj);
+
+    expect(errors[0].constraints).toMatchInlineSnapshot(`
+      Object {
+        "isNotEmpty": "name should not be empty",
+      }
+    `);
+  });
+  it('should fail when the given email is NOT an email', async () => {
+    const dto = dtoBuilder({
+      overrides: {
+        email: 'not_email',
+      },
+    });
+
+    const obj = plainToInstance(CreateUserDto, dto);
+
+    const errors = await validate(obj);
+
+    expect(errors[0].constraints).toMatchInlineSnapshot(`
+      Object {
+        "isEmail": "email must be an email",
+      }
+    `);
+  });
+  it('should fail when the given password length is less than 8', async () => {
+    const dto = dtoBuilder({
+      overrides: {
+        password: '8',
+      },
+    });
+
+    const obj = plainToInstance(CreateUserDto, dto);
+
+    const errors = await validate(obj);
+
+    expect(errors[0].constraints).toMatchInlineSnapshot(`
+      Object {
+        "minLength": "password must be longer than or equal to 8 characters",
+      }
+    `);
+  });
+});

--- a/apps/api/src/auth/dtos/create-user.dto.ts
+++ b/apps/api/src/auth/dtos/create-user.dto.ts
@@ -1,5 +1,12 @@
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+
 export class CreateUserDto {
+  @IsNotEmpty()
   name: string;
+
+  @IsEmail()
   email: string;
+
+  @MinLength(8)
   password: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4427,6 +4427,19 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+class-transformer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
+
+class-validator@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.13.2.tgz#64b031e9f3f81a1e1dcd04a5d604734608b24143"
+  integrity sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==
+  dependencies:
+    libphonenumber-js "^1.9.43"
+    validator "^13.7.0"
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -7470,6 +7483,11 @@ libnpmpublish@^6.0.4:
     semver "^7.3.7"
     ssri "^9.0.0"
 
+libphonenumber-js@^1.9.43:
+  version "1.10.14"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.14.tgz#e29da7f539751f724ac54017a098e3c7ca23de94"
+  integrity sha512-McGS7GV/WjJ2KjfOGhJU1oJn29RYeo7Q+RpANRbUNMQ9gj5XArpbjurSuyYPTejFwbaUojstQ4XyWCrAzGOUXw==
+
 light-my-request@5.6.1, light-my-request@^5.6.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-5.6.1.tgz#cff5c75d8cb35a354433d75406fea74a2f8bcdb1"
@@ -10450,6 +10468,11 @@ validate-npm-package-name@^4.0.0:
   integrity sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==
   dependencies:
     builtins "^5.0.0"
+
+validator@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary

- :sparkles: Add Validation to POST /auth/local/register
  - Setup Built-in ValidationPipe from Nest.js
    - Override its `exceptionFactory` to return a list of validation errors (See the below example) 
  - Validate CreateUserDto
    -  `name` must not be empty
    -  `email` must be an email
    -  `password` must be long than or equal to 8 characters

### Example of Validation Error Response
```json
{
  "statusCode": 422,
  "message": "Validation Failed"
  "fields": [
    {
      "name": "Name of the property that fails the validation",
      "code": "Name of validation constraint",
      "message": "Validation error message"
    }
  ]
} 
```
