### PR TITLE
:sparkles: Throw 422 Error when the given email has already been taken

### DIFF
--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -1,5 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import {
+  HttpStatus,
+  Injectable,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import type { User } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import { PrismaService } from '../prisma.service';
 
 type UserCreateInput = Pick<User, 'email' | 'name' | 'password'>;
@@ -25,12 +30,34 @@ export class UserService {
   }
 
   async create({ name, email, password }: UserCreateInput): Promise<User> {
-    return this.prisma.user.create({
-      data: {
-        name,
-        email,
-        password,
-      },
-    });
+    try {
+      const user = await this.prisma.user.create({
+        data: {
+          name,
+          email,
+          password,
+        },
+      });
+      return user;
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        switch (error.code) {
+          // Unique constraint failed. Ref: https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
+          case 'P2002':
+            throw new UnprocessableEntityException({
+              statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+              message: `Validation Failed`,
+              fields: [
+                {
+                  name: 'email',
+                  code: 'notUnique',
+                  message: `The email \`${email}\` has been taken`,
+                },
+              ],
+            });
+        }
+      }
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- When POST `/auth/local/register` is triggered
  - If the given email has already been taken by another user, throw 422 Unprocessable Entity Response in the similar manner as our Validation Pipe. 
    - See #23