### PR TITLE
:sparkles: By default, show every `FetchError` as an error toast

### DIFF
--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,18 +1,58 @@
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, Text, useToast } from '@chakra-ui/react';
 import {
   Hydrate,
+  MutationCache,
+  QueryCache,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
+import { FetchError } from '../src/api/utils';
 import { AuthProvider } from '../src/Hooks/useAuth';
 
 function MyApp({
   Component,
   pageProps,
 }: AppProps<{ dehydratedState: Record<string, unknown> }>) {
-  const [queryClient] = useState(() => new QueryClient());
+  const toast = useToast();
+
+  function showFetchErrorToast(error: FetchError) {
+    toast({
+      title: 'Something went wrong',
+      description: (
+        <>
+          <Text>Network error: {error.message}</Text>
+          <Text>
+            Please check your internet connection or contact our support
+          </Text>
+        </>
+      ),
+      status: 'error',
+      duration: 5000,
+      isClosable: true,
+    });
+  }
+
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        mutationCache: new MutationCache({
+          onError: (error) => {
+            if (error instanceof FetchError) {
+              showFetchErrorToast(error);
+            }
+          },
+        }),
+        queryCache: new QueryCache({
+          onError: (error) => {
+            if (error instanceof FetchError) {
+              showFetchErrorToast(error);
+            }
+          },
+        }),
+      })
+  );
 
   return (
     <ChakraProvider>


### PR DESCRIPTION
## Summary

- For every API function, if there is any FetchError
  - Show an error toast

<img width="553" alt="Screen Shot 2565-10-31 at 17 19 10" src="https://user-images.githubusercontent.com/3918933/198985939-b7f7354e-a33c-4e2c-9c49-11f9531457b3.png">
